### PR TITLE
Removing .forRoot() from all FlexLayoutModules

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,10 +35,10 @@
     "zone.js": "^0.7.2"
   },
   "devDependencies": {
+    "@angular/cli": "^1.0.0-beta.31",
     "@angular/compiler-cli": "^2.3.1",
     "@types/jasmine": "2.5.38",
     "@types/node": "^6.0.42",
-    "angular-cli": "1.0.0-beta.26",
     "codelyzer": "~2.0.0-beta.1",
     "jasmine-core": "2.5.2",
     "jasmine-spec-reporter": "2.5.0",

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -31,7 +31,7 @@ import {AvatarModule} from "../avatar/avatar.module";
         HttpModule,
         RouterModule.forRoot([], {useHash: false}),
         MaterialModule.forRoot(),
-        FlexLayoutModule.forRoot(),
+        FlexLayoutModule,
 
         AuthModule,
         FirebaseModule,

--- a/src/avatar/avatar.module.ts
+++ b/src/avatar/avatar.module.ts
@@ -14,7 +14,7 @@ import {AvatarComponent} from "./avatar.component";
         CommonModule,
         FormsModule,
         MaterialModule.forRoot(),
-        FlexLayoutModule.forRoot()
+        FlexLayoutModule
     ],
     exports: [
         AvatarComponent

--- a/src/create/create.module.ts
+++ b/src/create/create.module.ts
@@ -26,7 +26,7 @@ const routes: Routes = [
         CommonModule,
         FormsModule,
         MaterialModule.forRoot(),
-        FlexLayoutModule.forRoot(),
+        FlexLayoutModule,
         RouterModule.forChild(routes)
     ],
     providers: [

--- a/src/gallery/gallery.module.ts
+++ b/src/gallery/gallery.module.ts
@@ -25,7 +25,7 @@ const routes: Routes = [
         CommonModule,
         FormsModule,
         MaterialModule.forRoot(),
-        FlexLayoutModule.forRoot(),
+        FlexLayoutModule,
         RouterModule.forChild(routes)
     ],
     providers: [

--- a/src/landing/landing.module.ts
+++ b/src/landing/landing.module.ts
@@ -24,7 +24,7 @@ const routes: Routes = [
         CommonModule,
         FormsModule,
         MaterialModule.forRoot(),
-        FlexLayoutModule.forRoot(),
+        FlexLayoutModule,
         RouterModule.forChild(routes)
     ],
     providers: [

--- a/src/sign-in/sign-in.module.ts
+++ b/src/sign-in/sign-in.module.ts
@@ -19,7 +19,7 @@ const routes: Routes = [
         CommonModule,
         FormsModule,
         MaterialModule.forRoot(),
-        FlexLayoutModule.forRoot(),
+        FlexLayoutModule,
         RouterModule.forChild(routes)
     ],
     providers: []


### PR DESCRIPTION
.forRoot call is deprecated